### PR TITLE
Fix crate build with clang/LLVM 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 bitflags = "^1.3"
-blkid-sys = "^0.1"
+blkid-sys = { git = "https://github.com/elastio/blkid-sys", branch = "fix/3-update-bindgen" }
 libc = "^0.2"
 strum = "^0.23"
 strum_macros = "^0.23"

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -426,7 +426,7 @@ impl Prober {
 
     /// Returns name of a supported partition.
     #[cfg(blkid = "2.30")]
-    pub fn partitions_get_name(idx: u64) -> BlkIdResult<String> {
+    pub fn partitions_get_name(idx: usize) -> BlkIdResult<String> {
         let mut name: *const ::libc::c_char = ptr::null();
         unsafe { c_result(blkid_partitions_get_name(idx, &mut name)) }?;
         let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };


### PR DESCRIPTION
The dependent carate `blkid-sys` has already a fix in `master` but it was not released yet. And we are using this custom fork with the custom branch. So, I have to update it with the fix.