### PR TITLE
Remove git dependency for `blkid-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 bitflags = "^1.3"
-blkid-sys = { git = "https://github.com/elastio/blkid-sys", branch = "fix/3-update-bindgen" }
+blkid-sys = "^0.1"
 libc = "^0.2"
 strum = "^0.23"
 strum_macros = "^0.23"


### PR DESCRIPTION
New version v0.1.7 of `blkid-sys` is released. It has a fix for new `bindgen` v0.65.1 and compilable with clang 16.
And `cargo-deny` complains about git dependency.